### PR TITLE
Fix lint issues: remove unused imports and variables

### DIFF
--- a/katlibs_gui.py
+++ b/katlibs_gui.py
@@ -1,8 +1,6 @@
 import tkinter as tk
 from tkinter import ttk, scrolledtext
-import katlibs
 from tkinter import font as tkfont
-import random
 
 class KATLibsGUI:
     def __init__(self, root):
@@ -160,8 +158,8 @@ Legendary. {inputs['emoji']}
 
 def main():
     root = tk.Tk()
-    app = KATLibsGUI(root)
+    KATLibsGUI(root)
     root.mainloop()
 
 if __name__ == "__main__":
-    main() 
+    main()  


### PR DESCRIPTION
# Fix Lint Issues in KATLibs GUI

This PR addresses 3 lint issues identified by `ruff check .` in the `katlibs_gui.py` file:

## Changes Made

1. **Removed unused import `katlibs`** (line 3)
   - The `katlibs` module was imported but never used in the GUI implementation
   
2. **Removed unused import `random`** (line 5)  
   - The `random` module was imported but never used in the GUI implementation
   
3. **Fixed unused variable assignment `app`** (line 163)
   - Changed `app = KATLibsGUI(root)` to `KATLibsGUI(root)` since the variable was never used

## Verification

- ✅ `ruff check .` now passes with no lint errors
- ✅ All unit tests continue to pass (`python -m unittest tests.py -v`)
- ✅ No functional changes - GUI application works exactly the same

## Testing

The changes are purely cleanup and don't affect functionality. The KATLibs GUI application continues to work as expected, creating K-pop themed Mad Libs stories with the same interactive interface.

---

**Link to Devin run:** https://app.devin.ai/sessions/01ba50e465b649d2b47a4cdbd86cec1a

**Requested by:** Shay Strong (shay.strong@iceye.com)
